### PR TITLE
Added option to accommodate older Nano boards

### DIFF
--- a/amake
+++ b/amake
@@ -119,6 +119,9 @@ which_board() {
         nano328)
             MCUSTR="arduino:avr:nano:cpu=atmega328"
             ;;
+        nano328old)
+            MCUSTR="arduino:avr:nano:cpu=atmega328old"
+            ;;
         ng)
             MCUSTR="arduino:avr:atmegang:cpu=atmega168"
             ;;


### PR DESCRIPTION
        - option "nano328old" for Nano boards with older bootloader