### PR TITLE
Fix bug, that serial -s does not work with custom port

### DIFF
--- a/amake
+++ b/amake
@@ -799,7 +799,7 @@ case "$1" in
         stty -F "$PORTS" cs8 "$SPEED" ignbrk -brkint -icrnl -imaxbel -opost -onlcr -isig -icanon -iexten -echo -echoe -echok -echoctl -echoke noflsh -ixon -crtscts raw
 
         # connect to it
-        cat < $SERIAL
+        cat < $PORTS
         ;;
 
     *)


### PR DESCRIPTION
Fix for issue "Serial monitor doesn't work with custom port #10"